### PR TITLE
Adapt URL for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -->
 [![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://trixi-framework.github.io/TrixiAtmo.jl/dev)
 [![Slack](https://img.shields.io/badge/chat-slack-e01e5a)](https://join.slack.com/t/trixi-framework/shared_invite/zt-sgkc6ppw-6OXJqZAD5SPjBYqLd8MU~g)
-[![Build Status](https://github.com/trixi-framework/TrixiAtmo.jl/workflows/CI/badge.svg)](https://github.com/trixi-framework/TrixiAtmo.jl/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/trixi-framework/TrixiAtmo.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/trixi-framework/TrixiAtmo.jl/actions?query=workflow%3ACI)
 [![Codecov](https://codecov.io/gh/trixi-framework/TrixiAtmo.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/trixi-framework/TrixiAtmo.jl)
 [![Coveralls](https://coveralls.io/repos/github/trixi-framework/TrixiAtmo.jl/badge.svg?branch=main)](https://coveralls.io/github/trixi-framework/TrixiAtmo.jl?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Adapt URL according to the scheme in the docs https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name