### PR TITLE
Specialize `save_solution_file` for `AbstractCovariantEquations` to support `solution_variables` which depend on auxiliary variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Benedict Geihe <bgeihe@uni-koeln.de>", "Tristan Montoya <montoya.tri
 version = "0.1.0-DEV"
 
 [deps]
-HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
@@ -18,7 +17,6 @@ StrideArrays = "d1fa6d79-ef01-42a6-86c9-f7c551f8593b"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
-HDF5 = "0.17"
 LinearAlgebra = "1"
 LoopVectorization = "0.12.118"
 MuladdMacro = "0.2.2"

--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,12 @@ StrideArrays = "d1fa6d79-ef01-42a6-86c9-f7c551f8593b"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
 
 [compat]
+HDF5 = "0.17"
 LinearAlgebra = "1"
 LoopVectorization = "0.12.118"
 MuladdMacro = "0.2.2"
 NLsolve = "4.5.1"
+Printf = "1"
 Reexport = "1.0"
 Static = "0.8, 1"
 StaticArrayInterface = "1.5.1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Benedict Geihe <bgeihe@uni-koeln.de>", "Tristan Montoya <montoya.tri
 version = "0.1.0-DEV"
 
 [deps]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArrayInterface = "0d7ed370-da01-4f52-bd93-41d350b8b718"

--- a/examples/elixir_spherical_advection_covariant.jl
+++ b/examples/elixir_spherical_advection_covariant.jl
@@ -48,7 +48,7 @@ analysis_callback = AnalysisCallback(semi, interval = 10,
 
 # The SaveSolutionCallback allows to save the solution to a file in regular intervals
 save_solution = SaveSolutionCallback(interval = 10,
-                                     solution_variables = cons2cons)
+                                     solution_variables = contravariant2spherical)
 
 # The StepsizeCallback handles the re-calculation of the maximum Δt after each time step
 stepsize_callback = StepsizeCallback(cfl = 0.7)

--- a/src/TrixiAtmo.jl
+++ b/src/TrixiAtmo.jl
@@ -10,7 +10,9 @@ module TrixiAtmo
 
 using Reexport: @reexport
 using Trixi
+using HDF5: HDF5, h5open, attributes
 using MuladdMacro: @muladd
+using Printf: @sprintf
 using Static: True, False
 using StrideArrays: PtrArray
 using StaticArrayInterface: static_size

--- a/src/TrixiAtmo.jl
+++ b/src/TrixiAtmo.jl
@@ -10,7 +10,6 @@ module TrixiAtmo
 
 using Reexport: @reexport
 using Trixi
-using HDF5: HDF5, h5open, attributes
 using MuladdMacro: @muladd
 using Printf: @sprintf
 using Static: True, False

--- a/src/callbacks_step/analysis_covariant.jl
+++ b/src/callbacks_step/analysis_covariant.jl
@@ -11,13 +11,13 @@ function Trixi.analyze(::typeof(Trixi.entropy_timederivative), du, u, t,
     Trixi.integrate_via_indices(u, mesh, equations, dg, cache,
                                 du) do u, i, j, element, equations, dg, du_node
         # Get auxiliary variables, solution variables, and time derivative at given node
-        a_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
+        aux_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
         u_node = Trixi.get_node_vars(u, equations, dg, i, j, element)
         du_node = Trixi.get_node_vars(du, equations, dg, i, j, element)
 
         # compute ∂S/∂u ⋅ ∂u/∂t, where the entropy variables ∂S/∂u depend on the solution 
         # and auxiliary variables
-        dot(cons2entropy(u_node, a_node, equations), du_node)
+        dot(cons2entropy(u_node, aux_node, equations), du_node)
     end
 end
 
@@ -44,15 +44,15 @@ function Trixi.calc_error_norms(func, u, t, analyzer, mesh::P4estMesh{2},
 
             # Convert exact solution into contravariant components using geometric
             # information stored in aux vars
-            a_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
-            u_exact = initial_condition(x_node, t, a_node, equations)
+            aux_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
+            u_exact = initial_condition(x_node, t, aux_node, equations)
 
             # Compute the difference as usual
             u_numerical = Trixi.get_node_vars(u, equations, dg, i, j, element)
             diff = func(u_exact, equations) - func(u_numerical, equations)
 
             # For the L2 error, integrate with respect to volume element stored in aux vars 
-            sqrtG = area_element(a_node, equations)
+            sqrtG = area_element(aux_node, equations)
             l2_error += diff .^ 2 * (weights[i] * weights[j] * sqrtG)
 
             # Compute Linf error as usual

--- a/src/callbacks_step/callbacks_step.jl
+++ b/src/callbacks_step/callbacks_step.jl
@@ -1,2 +1,3 @@
 include("analysis_covariant.jl")
+include("save_solution_covariant.jl")
 include("stepsize_dg2d.jl")

--- a/src/callbacks_step/save_solution_covariant.jl
+++ b/src/callbacks_step/save_solution_covariant.jl
@@ -26,7 +26,7 @@ function convert_variables(u, solution_variables, mesh::P4estMesh{2},
     return data
 end
 
-# Version of save solution file that supports a solution_variables function that depends on 
+# Version of save_solution_file that supports a solution_variables function that depends on 
 # auxiliary variables
 function Trixi.save_solution_file(u, time, dt, timestep,
                                   mesh::Union{Trixi.SerialTreeMesh, StructuredMesh,

--- a/src/callbacks_step/save_solution_covariant.jl
+++ b/src/callbacks_step/save_solution_covariant.jl
@@ -26,8 +26,8 @@ function convert_variables(u, solution_variables, mesh::P4estMesh{2},
     return data
 end
 
-# Version of save_solution_file that supports a solution_variables function that depends on 
-# auxiliary variables
+# Specialized save_solution_file method that supports a solution_variables function 
+# depending on auxiliary variables
 function Trixi.save_solution_file(u, time, dt, timestep,
                                   mesh::Union{Trixi.SerialTreeMesh, StructuredMesh,
                                               StructuredMeshView,

--- a/src/callbacks_step/save_solution_covariant.jl
+++ b/src/callbacks_step/save_solution_covariant.jl
@@ -16,8 +16,8 @@ function convert_variables(u, solution_variables, mesh::P4estMesh{2},
     Trixi.@threaded for element in eachelement(dg, cache)
         for j in eachnode(dg), i in eachnode(dg)
             u_node = Trixi.get_node_vars(u, equations, dg, i, j, element)
-            a_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
-            u_node_converted = solution_variables(u_node, a_node, equations)
+            aux_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
+            u_node_converted = solution_variables(u_node, aux_node, equations)
             for v in 1:n_vars
                 data[v, i, j, element] = u_node_converted[v]
             end

--- a/src/callbacks_step/save_solution_covariant.jl
+++ b/src/callbacks_step/save_solution_covariant.jl
@@ -1,0 +1,88 @@
+# Saves all solution variables in addition to the relative vorticity
+function Trixi.save_solution_file(u, time, dt, timestep,
+                                  mesh::Union{Trixi.SerialTreeMesh, StructuredMesh,
+                                              StructuredMeshView,
+                                              UnstructuredMesh2D, Trixi.SerialP4estMesh,
+                                              Trixi.SerialT8codeMesh},
+                                  equations::AbstractCovariantEquations, dg::DG,
+                                  cache,
+                                  solution_callback,
+                                  element_variables = Dict{Symbol, Any}(),
+                                  node_variables = Dict{Symbol, Any}();
+                                  system = "")
+    (; output_directory, solution_variables) = solution_callback
+    (; aux_node_vars) = cache.auxiliary_variables
+
+    # Filename based on current time step
+    if isempty(system)
+        filename = joinpath(output_directory, @sprintf("solution_%09d.h5", timestep))
+    else
+        filename = joinpath(output_directory,
+                            @sprintf("solution_%s_%09d.h5", system, timestep))
+    end
+
+    # Convert to different set of variables if requested
+    if solution_variables === cons2cons
+        data = u
+        n_vars_cons = nvariables(equations)
+    else
+        # Reinterpret the solution array as an array of conservative variables,
+        # compute the solution variables via broadcasting, and reinterpret the
+        # result as a plain array of floating point numbers
+        data = Array(reinterpret(eltype(u),
+                                 solution_variables.(reinterpret(SVector{nvariables(equations),
+                                                                         eltype(u)},
+                                                                 u, aux_node_vars),
+                                                     Ref(equations))))
+
+        # Find out variable count by looking at output from `solution_variables` function
+        n_vars_cons = size(data, 1)
+    end
+
+    # Open file (clobber existing content)
+    h5open(filename, "w") do file
+        # Add context information as attributes
+        attributes(file)["ndims"] = ndims(mesh)
+        attributes(file)["equations"] = Trixi.get_name(equations)
+        attributes(file)["polydeg"] = Trixi.polydeg(dg)
+        attributes(file)["n_vars"] = n_vars_cons + 1
+        attributes(file)["n_elements"] = nelements(dg, cache)
+        attributes(file)["mesh_type"] = Trixi.get_name(mesh)
+        attributes(file)["mesh_file"] = splitdir(mesh.current_filename)[2]
+        attributes(file)["time"] = convert(Float64, time) # Ensure that `time` is written as a double precision scalar
+        attributes(file)["dt"] = convert(Float64, dt) # Ensure that `dt` is written as a double precision scalar
+        attributes(file)["timestep"] = timestep
+
+        # Store each variable of the solution data
+        for v in 1:n_vars_cons
+            # Convert to 1D array
+            file["variables_$v"] = vec(data[v, .., :])
+
+            # Add variable name as attribute
+            var = file["variables_$v"]
+            attributes(var)["name"] = Trixi.varnames(solution_variables, equations)[v]
+        end
+
+        # Store element variables
+        for (v, (key, element_variable)) in enumerate(element_variables)
+            # Add to file
+            file["element_variables_$v"] = element_variable
+
+            # Add variable name as attribute
+            var = file["element_variables_$v"]
+            attributes(var)["name"] = string(key)
+        end
+
+        # Store node variables
+        for (v, (key, node_variable)) in enumerate(node_variables)
+            # Add to file
+            file["node_variables_$v"] = node_variable
+
+            # Add variable name as attribute
+            var = file["node_variables_$v"]
+            attributes(var)["name"] = string(key)
+        end
+    end
+
+    return filename
+end

--- a/src/callbacks_step/stepsize_dg2d.jl
+++ b/src/callbacks_step/stepsize_dg2d.jl
@@ -59,8 +59,8 @@ function Trixi.max_dt(u, t, mesh::P4estMesh{2}, constant_speed::False,
         max_lambda1 = max_lambda2 = zero(max_scaled_speed)
         for j in eachnode(dg), i in eachnode(dg)
             u_node = Trixi.get_node_vars(u, equations, dg, i, j, element)
-            a_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
-            lambda1, lambda2 = Trixi.max_abs_speeds(u_node, a_node, equations)
+            aux_node = get_node_aux_vars(aux_node_vars, equations, dg, i, j, element)
+            lambda1, lambda2 = Trixi.max_abs_speeds(u_node, aux_node, equations)
             max_lambda1 = max(max_lambda1, lambda1)
             max_lambda2 = max(max_lambda2, lambda2)
         end

--- a/src/equations/covariant_advection.jl
+++ b/src/equations/covariant_advection.jl
@@ -47,6 +47,26 @@ function velocity(u, ::CovariantLinearAdvectionEquation2D)
     return SVector(u[2], u[3])
 end
 
+# Convert contravariant velocity/momentum components to zonal and meridional components
+@inline function contravariant2spherical(u, aux_vars,
+                                         equations::CovariantLinearAdvectionEquation2D)
+    vlon, vlat = basis_covariant(aux_vars, equations) * velocity(u, equations)
+    return SVector(u[1], vlon, vlat)
+end
+
+# Convert zonal and meridional velocity/momentum components to contravariant components
+@inline function spherical2contravariant(u_spherical, aux_vars,
+                                         equations::CovariantLinearAdvectionEquation2D)
+    vcon1, vcon2 = basis_covariant(aux_vars, equations) \
+                   velocity(u_spherical, equations)
+    return SVector(u_spherical[1], vcon1, vcon2)
+end
+
+function Trixi.varnames(::typeof(contravariant2spherical),
+                        ::CovariantLinearAdvectionEquation2D)
+    return ("scalar", "vlon", "vlat")
+end
+
 # We will define the "entropy variables" here to just be the scalar variable in the first 
 # slot, with zeros in the second and third positions
 @inline function Trixi.cons2entropy(u, aux_vars,
@@ -90,20 +110,5 @@ end
 @inline function Trixi.max_abs_speeds(u, aux_vars,
                                       equations::CovariantLinearAdvectionEquation2D)
     return abs.(velocity(u, equations))
-end
-
-# Convert contravariant velocity/momentum components to zonal and meridional components
-@inline function contravariant2spherical(u, aux_vars,
-                                         equations::CovariantLinearAdvectionEquation2D)
-    vlon, vlat = basis_covariant(aux_vars, equations) * velocity(u, equations)
-    return SVector(u[1], vlon, vlat)
-end
-
-# Convert zonal and meridional velocity/momentum components to contravariant components
-@inline function spherical2contravariant(u_spherical, aux_vars,
-                                         equations::CovariantLinearAdvectionEquation2D)
-    vcon1, vcon2 = basis_covariant(aux_vars, equations) \
-                   velocity(u_spherical, equations)
-    return SVector(u_spherical[1], vcon1, vcon2)
 end
 end # @muladd

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -51,6 +51,10 @@ dispatching on the return type.
 # cons2cons method which takes in unused aux_vars variable
 @inline Trixi.cons2cons(u, aux_vars, equations) = u
 
+# If no auxiliary variables are passed into the conversion to spherical coordinates, do not 
+# do any conversion.
+@inline contravariant2spherical(u, equations) = u
+
 # For the covariant form, the auxiliary variables are the the NDIMS^2 entries of the 
 # covariant basis matrix
 @inline have_aux_node_vars(::AbstractCovariantEquations) = True()

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -117,6 +117,31 @@ end
     return 0.5f0 * (flux_ll + flux_rr)
 end
 
+# Transform zonal and meridional velocity/momentum components to Cartesian components
+function spherical2cartesian(vlon, vlat, x)
+    # Co-latitude
+    colat = acos(x[3] / sqrt(x[1]^2 + x[2]^2 + x[3]^2))
+
+    # Longitude
+    if sign(x[2]) == 0.0
+        signy = 1.0
+    else
+        signy = sign(x[2])
+    end
+    r_xy = sqrt(x[1]^2 + x[2]^2)
+    if r_xy == 0.0
+        lon = pi / 2
+    else
+        lon = signy * acos(x[1] / r_xy)
+    end
+
+    v1 = -cos(colat) * cos(lon) * vlat - sin(lon) * vlon
+    v2 = -cos(colat) * sin(lon) * vlat + cos(lon) * vlon
+    v3 = sin(colat) * vlat
+
+    return SVector(v1, v2, v3)
+end
+
 abstract type AbstractCompressibleMoistEulerEquations{NDIMS, NVARS} <:
               AbstractEquations{NDIMS, NVARS} end
 

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -117,31 +117,6 @@ end
     return 0.5f0 * (flux_ll + flux_rr)
 end
 
-# Transform zonal and meridional velocity/momentum components to Cartesian components
-function spherical2cartesian(vlon, vlat, x)
-    # Co-latitude
-    colat = acos(x[3] / sqrt(x[1]^2 + x[2]^2 + x[3]^2))
-
-    # Longitude
-    if sign(x[2]) == 0.0
-        signy = 1.0
-    else
-        signy = sign(x[2])
-    end
-    r_xy = sqrt(x[1]^2 + x[2]^2)
-    if r_xy == 0.0
-        lon = pi / 2
-    else
-        lon = signy * acos(x[1] / r_xy)
-    end
-
-    v1 = -cos(colat) * cos(lon) * vlat - sin(lon) * vlon
-    v2 = -cos(colat) * sin(lon) * vlat + cos(lon) * vlon
-    v3 = sin(colat) * vlat
-
-    return SVector(v1, v2, v3)
-end
-
 abstract type AbstractCompressibleMoistEulerEquations{NDIMS, NVARS} <:
               AbstractEquations{NDIMS, NVARS} end
 

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -48,6 +48,9 @@ dispatching on the return type.
 """
 @inline have_aux_node_vars(::AbstractEquations) = False()
 
+# cons2cons method which takes in unused aux_vars variable
+@inline Trixi.cons2cons(u, aux_vars, equations) = u
+
 # For the covariant form, the auxiliary variables are the the NDIMS^2 entries of the 
 # covariant basis matrix
 @inline have_aux_node_vars(::AbstractCovariantEquations) = True()

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -381,31 +381,6 @@ end
     return energy_total(cons, equations) - energy_kinetic(cons, equations)
 end
 
-# Transform zonal and meridional velocity/momentum components to Cartesian components
-function spherical2cartesian(vlon, vlat, x)
-    # Co-latitude
-    colat = acos(x[3] / sqrt(x[1]^2 + x[2]^2 + x[3]^2))
-
-    # Longitude
-    if sign(x[2]) == 0.0
-        signy = 1.0
-    else
-        signy = sign(x[2])
-    end
-    r_xy = sqrt(x[1]^2 + x[2]^2)
-    if r_xy == 0.0
-        lon = pi / 2
-    else
-        lon = signy * acos(x[1] / r_xy)
-    end
-
-    v1 = -cos(colat) * cos(lon) * vlat - sin(lon) * vlon
-    v2 = -cos(colat) * sin(lon) * vlat + cos(lon) * vlon
-    v3 = sin(colat) * vlat
-
-    return SVector(v1, v2, v3)
-end
-
 @doc raw"""
     transform_to_cartesian(initial_condition, equations)
 

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -381,6 +381,31 @@ end
     return energy_total(cons, equations) - energy_kinetic(cons, equations)
 end
 
+# Transform zonal and meridional velocity/momentum components to Cartesian components
+function spherical2cartesian(vlon, vlat, x)
+    # Co-latitude
+    colat = acos(x[3] / sqrt(x[1]^2 + x[2]^2 + x[3]^2))
+
+    # Longitude
+    if sign(x[2]) == 0.0
+        signy = 1.0
+    else
+        signy = sign(x[2])
+    end
+    r_xy = sqrt(x[1]^2 + x[2]^2)
+    if r_xy == 0.0
+        lon = pi / 2
+    else
+        lon = signy * acos(x[1] / r_xy)
+    end
+
+    v1 = -cos(colat) * cos(lon) * vlat - sin(lon) * vlon
+    v2 = -cos(colat) * sin(lon) * vlat + cos(lon) * vlon
+    v3 = sin(colat) * vlat
+
+    return SVector(v1, v2, v3)
+end
+
 @doc raw"""
     transform_to_cartesian(initial_condition, equations)
 


### PR DESCRIPTION
This PR specializes `Trixi.save_solution_file` for the covariant form to allow for variable conversions that depend on auxiliary variables, and may return a different number of variables than `nvariables(equations)`. Specifically, equations of type `AbstractCovariantEquations` should use `solution_variables(u, aux_vars, equations)` instead of `solution_variables(u, equations)`. A default `cons2cons(u, aux_vars, equations) = u` option has been defined.