### PR TITLE
Quick fix to multithreading issue by refining specialization of contravariant vectors

### DIFF
--- a/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
+++ b/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
@@ -49,7 +49,8 @@ end
 # parameter of PtrArray is Tuple{StaticInt{NDIMS_AMBIENT}, Vararg{IntT, NDIMS + 2}}.
 @inline function Trixi.get_contravariant_vector(index,
                                                 contravariant_vectors::PtrArray{RealT,
-                                                                                5, <:Any,
+                                                                                5,
+                                                                                <:Any,
                                                                                 Tuple{Trixi.StaticInt{3},
                                                                                       IntT,
                                                                                       IntT,

--- a/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
+++ b/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
@@ -43,21 +43,19 @@ end
     return uEltype
 end
 
-static2val(::Trixi.StaticInt{N}) where {N} = Val{N}()
-
 # Extract contravariant vector Ja^i (i = index) as SVector. This function dispatches on the 
 # type of contravariant_vectors, specializing for NDIMS = 2 and NDIMS_AMBIENT = 3 by using 
 # the fact that the second type parameter of PtrArray is NDIMS + 3, and the fourth type 
 # parameter of PtrArray is Tuple{StaticInt{NDIMS_AMBIENT}, Vararg{IntT, NDIMS + 2}}.
 @inline function Trixi.get_contravariant_vector(index,
                                                 contravariant_vectors::PtrArray{RealT,
-                                                                                5, R,
+                                                                                5, <:Any,
                                                                                 Tuple{Trixi.StaticInt{3},
                                                                                       IntT,
                                                                                       IntT,
                                                                                       IntT,
                                                                                       IntT}},
-                                                indices...) where {RealT, R, IntT}
+                                                indices...) where {RealT, IntT}
     return SVector(ntuple(@inline(dim->contravariant_vectors[dim, index, indices...]),
                           3))
 end

--- a/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
+++ b/src/solvers/dgsem_p4est/containers_2d_manifold_in_3d_cartesian.jl
@@ -43,14 +43,23 @@ end
     return uEltype
 end
 
-# Extract contravariant vector Ja^i (i = index) as SVector
-# This function dispatches on the type of contravariant_vectors
 static2val(::Trixi.StaticInt{N}) where {N} = Val{N}()
-@inline function Trixi.get_contravariant_vector(index, contravariant_vectors::PtrArray,
-                                                indices...)
+
+# Extract contravariant vector Ja^i (i = index) as SVector. This function dispatches on the 
+# type of contravariant_vectors, specializing for NDIMS = 2 and NDIMS_AMBIENT = 3 by using 
+# the fact that the second type parameter of PtrArray is NDIMS + 3, and the fourth type 
+# parameter of PtrArray is Tuple{StaticInt{NDIMS_AMBIENT}, Vararg{IntT, NDIMS + 2}}.
+@inline function Trixi.get_contravariant_vector(index,
+                                                contravariant_vectors::PtrArray{RealT,
+                                                                                5, R,
+                                                                                Tuple{Trixi.StaticInt{3},
+                                                                                      IntT,
+                                                                                      IntT,
+                                                                                      IntT,
+                                                                                      IntT}},
+                                                indices...) where {RealT, R, IntT}
     return SVector(ntuple(@inline(dim->contravariant_vectors[dim, index, indices...]),
-                          static2val(static_size(contravariant_vectors,
-                                                 Trixi.StaticInt(1)))))
+                          3))
 end
 
 # Create element container and initialize element data.


### PR DESCRIPTION
This is an attempt to fix the problem @benegee noted in #61, in which the cases which use "standard" Trixi.jl solvers (i.e. not those for PDEs on surfaces) return an error when multiple threads are used, due to TrixiAtmo.jl's specialized `get_contravariant_vector` method for `PtrArray` types being called inadvertently. I'm not super familiar with the workings of `PtrArray`, but looking at the [StrideArraysCore.jl](https://github.com/JuliaSIMD/StrideArraysCore.jl) code, I was able to figure out what type parameters would be associated with a 2D mesh in 3D space, and therefore hard-coded the dispatch for those dimensions. With this change, the issues in #61 are no longer encountered.