### PR TITLE
Fix links to source code from docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,8 +19,7 @@ DocMeta.setdocmeta!(TrixiAtmo, :DocTestSetup, :(using TrixiAtmo);
 makedocs(;
          modules = [TrixiAtmo],
          authors = "Benedict Geihe <bgeihe@uni-koeln.de>, Tristan Montoya <montoya.tristan@gmail.com, Hendrik Ranocha <hendrik.ranocha@uni-mainz.de>, Michael Schlottke-Lakemper <michael@sloede.com>",
-         repo = Remotes.GitHub("trixi-framework",
-                               "TrixiAtmo.jl/blob/{commit}{path}#{line}"),
+         repo = Remotes.GitHub("trixi-framework", "TrixiAtmo.jl"),
          sitename = "TrixiAtmo.jl",
          format = Documenter.HTML(;
                                   prettyurls = get(ENV, "CI", "false") == "true",


### PR DESCRIPTION
I think this fixes #65. Currently, the links go to a specific commit, as I haven't found a way to make them go to the default branch.