### PR TITLE
Fix typos in docs

### DIFF
--- a/src/equations/covariant_shallow_water_split.jl
+++ b/src/equations/covariant_shallow_water_split.jl
@@ -29,7 +29,7 @@ In the above, the non-conservative differential terms in the momentum equations 
 and the algebraic momentum source terms implemented in `source_terms_geometric_coriolis` 
 are given by
 ```math
-s^a = \frac{1}{2}\big(\Gamma_{bc}^a hu^bu^c - G^{ac}\Gamma_{bc}^d hu^b u_d \big) 
+s^a = -\frac{1}{2}\big(\Gamma_{bc}^a hu^bu^c - G^{ac}\Gamma_{bc}^d hu^b u_d \big) 
 - f JG^{ab}\varepsilon_{bc} hu^c,
 ```
 where we use the same notation as in [`CovariantShallowWaterEquations2D`](@ref) (including 

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -168,7 +168,7 @@ is nonzero this should only be used as a surface flux otherwise the scheme will 
 For well-balancedness in the volume flux use [`flux_wintermeyer_etal`](@ref).
 
 Details are available in Eq. (4.1) in the paper:
-- Ulrik S. Fjordholm, Siddhartha Mishr and Eitan Tadmor (2011)
+- Ulrik S. Fjordholm, Siddhartha Mishra and Eitan Tadmor (2011)
   Well-balanced and energy stable schemes for the shallow water equations with discontinuous topography
   [DOI: 10.1016/j.jcp.2011.03.042](https://doi.org/10.1016/j.jcp.2011.03.042)
 """


### PR DESCRIPTION
- S. Mishra's last name was misspelled in a reference.
- Negative sign was missing in the entropy-stable geometric source term.