### PR TITLE
Rename the keyword `gravity_constant` to `gravity` for the `ShallowWaterEquations3D`

### DIFF
--- a/examples/elixir_shallowwater_cubed_sphere_shell_EC_correction.jl
+++ b/examples/elixir_shallowwater_cubed_sphere_shell_EC_correction.jl
@@ -6,7 +6,7 @@ using TrixiAtmo
 # Entropy conservation for the spherical shallow water equations in Cartesian
 # form obtained through an entropy correction term
 
-equations = ShallowWaterEquations3D(gravity_constant = 9.81)
+equations = ShallowWaterEquations3D(gravity = 9.81)
 
 # Create DG solver with polynomial degree = 3 and Wintemeyer et al.'s flux as surface flux
 polydeg = 3

--- a/examples/elixir_shallowwater_cubed_sphere_shell_EC_projection.jl
+++ b/examples/elixir_shallowwater_cubed_sphere_shell_EC_projection.jl
@@ -8,7 +8,7 @@ using TrixiAtmo
 # form obtained through the projection of the momentum onto the divergence-free
 # tangential contravariant vectors
 
-equations = ShallowWaterEquations3D(gravity_constant = 9.81)
+equations = ShallowWaterEquations3D(gravity = 9.81)
 
 # Create DG solver with polynomial degree = 3 and Wintemeyer et al.'s flux as surface flux
 polydeg = 3

--- a/examples/elixir_shallowwater_cubed_sphere_shell_advection.jl
+++ b/examples/elixir_shallowwater_cubed_sphere_shell_advection.jl
@@ -21,7 +21,7 @@ cells_per_dimension = (5, 5)
 
 # We use the ShallowWaterEquations3D equations structure but modify the rhs! function to
 # convert it to a variable-coefficient advection equation
-equations = ShallowWaterEquations3D(gravity_constant = 0.0)
+equations = ShallowWaterEquations3D(gravity = 0.0)
 
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs)

--- a/examples/elixir_shallowwater_cubed_sphere_shell_standard.jl
+++ b/examples/elixir_shallowwater_cubed_sphere_shell_standard.jl
@@ -6,7 +6,7 @@ using TrixiAtmo
 # Entropy consistency test for the spherical shallow water equations in Cartesian
 # form using the standard DGSEM with LLF dissipation
 
-equations = ShallowWaterEquations3D(gravity_constant = 9.81)
+equations = ShallowWaterEquations3D(gravity = 9.81)
 
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs as surface flux
 polydeg = 3

--- a/examples/elixir_shallowwater_quad_icosahedron_shell_advection.jl
+++ b/examples/elixir_shallowwater_quad_icosahedron_shell_advection.jl
@@ -21,7 +21,7 @@ cells_per_dimension = (2, 2)
 
 # We use the ShallowWaterEquations3D equations structure but modify the rhs! function to
 # convert it to a variable-coefficient advection equation
-equations = ShallowWaterEquations3D(gravity_constant = 0.0)
+equations = ShallowWaterEquations3D(gravity = 0.0)
 
 # Create DG solver with polynomial degree = 3 and (local) Lax-Friedrichs/Rusanov flux as surface flux
 solver = DGSEM(polydeg = polydeg, surface_flux = flux_lax_friedrichs)

--- a/src/equations/covariant_shallow_water.jl
+++ b/src/equations/covariant_shallow_water.jl
@@ -16,7 +16,7 @@ on a two-dimensional surface in three-dimensional ambient space as
 \end{aligned}
 ```
 where $h$ is the fluid height, $v^a$ and $G^{ab}$ are the contravariant velocity and metric 
-tensor components, $g$ is the gravitational constant, $f$ is the Coriolis parameter, 
+tensor components, $g$ is the gravitational acceleration, $f$ is the Coriolis parameter, 
 $J$ is the area element, and $\partial_a$ is used as a shorthand for 
 $\partial / \partial \xi^a$. Combining the advective and pressure terms in order to define 
 the momentum flux components

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -19,7 +19,7 @@ The equations are given by
 \end{aligned}
 ```
 The unknown quantities of the SWE are the water height ``h`` and the velocities ``\mathbf{v} = (v_1, v_2, v_3)^T``.
-The gravitational constant is denoted by `g`.
+The gravitational acceleration is denoted by `g`.
 
 The 3D Shallow Water Equations (SWE) extend the 2D SWE to model shallow water flows on 2D manifolds embedded within 3D space. 
 To confine the flow to the 2D manifold, a source term incorporating a Lagrange multiplier is applied. 
@@ -48,17 +48,17 @@ References:
 """
 struct ShallowWaterEquations3D{RealT <: Real} <:
        Trixi.AbstractShallowWaterEquations{3, 5}
-    gravity::RealT # gravitational constant
+    gravity::RealT # gravitational acceleration
     H0::RealT      # constant "lake-at-rest" total water height
 end
 
-# Allow for flexibility to set the gravitational constant within an elixir depending on the
-# application where `gravity_constant=1.0` or `gravity_constant=9.81` are common values.
+# Allow for flexibility to set the gravitational acceleration within an elixir depending on the
+# application where `gravity=1.0` or `gravity=9.81` are common values.
 # The reference total water height H0 defaults to 0.0 but is used for the "lake-at-rest"
 # well-balancedness test cases.
-function ShallowWaterEquations3D(; gravity_constant, H0 = zero(gravity_constant))
-    T = promote_type(typeof(gravity_constant), typeof(H0))
-    ShallowWaterEquations3D(gravity_constant, H0)
+function ShallowWaterEquations3D(; gravity, H0 = zero(gravity))
+    T = promote_type(typeof(gravity), typeof(H0))
+    ShallowWaterEquations3D(gravity, H0)
 end
 
 Trixi.have_nonconservative_terms(::ShallowWaterEquations3D) = False() # Deactivate non-conservative terms for the moment...


### PR DESCRIPTION
This PR renames the `gravity_constant` keyword in the equations constructor to `gravity` and fixes the docstrings/comments to describe this quantity as the gravitational acceleration instead of the gravitational constant. This will make it consistent with the actual field equations.gravity and avoid any confusion between [gravitational acceleration](https://en.wikipedia.org/wiki/Gravitational_acceleration) and the [gravitational constant](https://en.wikipedia.org/wiki/Gravitational_constant). See https://github.com/trixi-framework/TrixiShallowWater.jl/issues/82, https://github.com/trixi-framework/TrixiShallowWater.jl/pull/84, https://github.com/trixi-framework/Trixi.jl/pull/2357