### PR TITLE
Qualified name for waterheight

### DIFF
--- a/src/TrixiAtmo.jl
+++ b/src/TrixiAtmo.jl
@@ -41,7 +41,7 @@ export flux_chandrashekar, FluxLMARS
 export flux_nonconservative_zeros, flux_nonconservative_ec,
        source_terms_geometric_coriolis
 
-export velocity, waterheight, pressure, energy_total, energy_kinetic, energy_internal,
+export velocity, pressure, energy_total, energy_kinetic, energy_internal,
        lake_at_rest_error, source_terms_lagrange_multiplier,
        clean_solution_lagrange_multiplier!
 

--- a/src/equations/covariant_shallow_water.jl
+++ b/src/equations/covariant_shallow_water.jl
@@ -92,7 +92,7 @@ function Trixi.varnames(::typeof(contravariant2global),
 end
 
 # Convenience functions to extract physical variables from state vector
-@inline waterheight(u, ::AbstractCovariantShallowWaterEquations2D) = u[1]
+@inline Trixi.waterheight(u, ::AbstractCovariantShallowWaterEquations2D) = u[1]
 @inline velocity_contravariant(u,
 ::AbstractCovariantShallowWaterEquations2D) = SVector(u[2] /
                                                       u[1],

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -346,7 +346,7 @@ end
     return SVector(h, h_v1, h_v2, h_v3, b)
 end
 
-@inline function waterheight(u, equations::ShallowWaterEquations3D)
+@inline function Trixi.waterheight(u, equations::ShallowWaterEquations3D)
     return u[1]
 end
 


### PR DESCRIPTION
`waterheight` is now exported by `Trixi.jl`: https://github.com/trixi-framework/Trixi.jl/pull/2352

IIUC, we therefore need to qualify the name and extend the method.