### PR TITLE
Fix docstrings for the `ShallowWaterEquations3D`

### DIFF
--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -115,7 +115,8 @@ end
 end
 
 """
-    flux_wintermeyer_etal(u_ll, u_rr, orientation_or_normal_direction,
+    flux_wintermeyer_etal(u_ll, u_rr,
+                          normal_direction::AbstractVector,
                           equations::ShallowWaterEquations3D)
 
 Total energy conservative (mathematical entropy for shallow water equations) split form.
@@ -160,7 +161,8 @@ Further details are available in Theorem 1 of the paper:
 end
 
 """
-    flux_fjordholm_etal(u_ll, u_rr, orientation,
+    flux_fjordholm_etal(u_ll, u_rr,
+                        normal_direction::AbstractVector,
                         equations::ShallowWaterEquations3D)
 
 Total energy conservative (mathematical entropy for shallow water equations). When the bottom topography

--- a/src/equations/shallow_water_3d.jl
+++ b/src/equations/shallow_water_3d.jl
@@ -116,7 +116,7 @@ end
 
 """
     flux_wintermeyer_etal(u_ll, u_rr, orientation_or_normal_direction,
-                          equations::ShallowWaterEquations2D)
+                          equations::ShallowWaterEquations3D)
 
 Total energy conservative (mathematical entropy for shallow water equations) split form.
 When the bottom topography is nonzero this scheme will be well-balanced when used as a `volume_flux`.
@@ -161,7 +161,7 @@ end
 
 """
     flux_fjordholm_etal(u_ll, u_rr, orientation,
-                        equations::ShallowWaterEquations1D)
+                        equations::ShallowWaterEquations3D)
 
 Total energy conservative (mathematical entropy for shallow water equations). When the bottom topography
 is nonzero this should only be used as a surface flux otherwise the scheme will not be well-balanced.


### PR DESCRIPTION
I noticed that the equations in some docstrings for the `ShallowWaterEquations3D` had a wrong dimension.