### PR TITLE
Use TrixiTest.jl

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,6 +5,7 @@ OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
 OrdinaryDiffEqSSPRK = "669c94d9-1f4b-4b64-b377-1aa079aa2388"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
+TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"
 
 [compat]
 NLsolve = "4.5.1"
@@ -13,3 +14,4 @@ OrdinaryDiffEqLowStorageRK = "1.2"
 OrdinaryDiffEqSSPRK = "1.2"
 Test = "1"
 Trixi = "0.9.9, 0.10, 0.11"
+TrixiTest = "0.1"

--- a/test/test_trixiatmo.jl
+++ b/test/test_trixiatmo.jl
@@ -1,4 +1,5 @@
 using Test: @test
+using TrixiTest: @trixi_test_nowarn
 using Trixi: Trixi, examples_dir, trixi_include
 import TrixiAtmo
 
@@ -125,55 +126,16 @@ end
 
 # Modified version of `@test_nowarn` that prints the content of `stderr` when
 # it is not empty and ignores module replacements.
-macro test_nowarn_mod(expr, additional_ignore_content = String[])
+macro test_nowarn_mod(expr, additional_ignore_content = [])
     quote
-        let fname = tempname()
-            try
-                ret = open(fname, "w") do f
-                    redirect_stderr(f) do
-                        $(esc(expr))
-                    end
-                end
-                stderr_content = read(fname, String)
-                if !isempty(stderr_content)
-                    println("Content of `stderr`:\n", stderr_content)
-                end
-
-                # Patterns matching the following ones will be ignored. Additional patterns
-                # passed as arguments can also be regular expressions, so we just use the
-                # type `Any` for `ignore_content`.
-                ignore_content = Any[
-                                     # We need to ignore steady state information reported by our callbacks
-                                     r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
-                                     # We also ignore our own compilation messages
-                                     "[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n",
-                                     # TODO: Upstream (PlotUtils). This should be removed again once the
-                                     #       deprecated stuff is fixed upstream.
-                                     "WARNING: importing deprecated binding Colors.RGB1 into Plots.\n",
-                                     "WARNING: importing deprecated binding Colors.RGB4 into Plots.\n",
-                                     r"┌ Warning: Keyword argument letter not supported with Plots.+\n└ @ Plots.+\n",
-                                     r"┌ Warning: `parse\(::Type, ::Coloarant\)` is deprecated.+\n│.+\n│.+\n└ @ Plots.+\n",
-                                     # TODO: Silence warning introduced by Flux v0.13.13. Should be properly fixed.
-                                     r"┌ Warning: Layer with Float32 parameters got Float64 input.+\n│.+\n│.+\n│.+\n└ @ Flux.+\n",
-                                     # NOTE: These warnings arose from Julia 1.10 onwards
-                                     r"WARNING: Method definition .* in module .* at .* overwritten .*.\n",
-                                     # Warnings from third party packages
-                                     r"┌ Warning: Problem status ALMOST_INFEASIBLE; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n",
-                                     r"┌ Warning: Problem status ALMOST_OPTIMAL; solution may be inaccurate.\n└ @ Convex ~/.julia/packages/Convex/.*\n"]
-                append!(ignore_content, $additional_ignore_content)
-                for pattern in ignore_content
-                    stderr_content = replace(stderr_content, pattern => "")
-                end
-
-                # We also ignore simple module redefinitions for convenience. Thus, we
-                # check whether every line of `stderr_content` is of the form of a
-                # module replacement warning.
-                @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
-                ret
-            finally
-                rm(fname, force = true)
-            end
-        end
+        add_to_additional_ignore_content = [
+            # We need to ignore steady state information reported by our callbacks
+            r"┌ Info:   Steady state tolerance reached\n│   steady_state_callback .+\n└   t = .+\n",
+            # NOTE: These warnings arose from Julia 1.10 onwards
+            r"WARNING: Method definition .* in module .* at .* overwritten .*.\n"
+        ]
+        append!($additional_ignore_content, add_to_additional_ignore_content)
+        @trixi_test_nowarn $(esc(expr)) $additional_ignore_content
     end
 end
 


### PR DESCRIPTION
This is the analogous PR to Trixi.jls https://github.com/trixi-framework/Trixi.jl/pull/2395, which simplifies the custom `@test_nowarn` a bit to reduce maintenance. The main part has been outsourced to TrixiTest.jl.