### PR TITLE
Remove surface_integral from prolong2interfaces

### DIFF
--- a/src/solvers/dgsem_p4est/dg_2d_manifold_in_3d_cartesian.jl
+++ b/src/solvers/dgsem_p4est/dg_2d_manifold_in_3d_cartesian.jl
@@ -20,8 +20,7 @@ function Trixi.rhs!(du, u, t,
 
     # Prolong solution to interfaces
     Trixi.@trixi_timeit Trixi.timer() "prolong2interfaces" begin
-        Trixi.prolong2interfaces!(cache, u, mesh, equations,
-                                  dg.surface_integral, dg)
+        Trixi.prolong2interfaces!(cache, u, mesh, equations, dg)
     end
 
     # Calculate interface fluxes


### PR DESCRIPTION
Xref: https://github.com/trixi-framework/Trixi.jl/pull/2434

This was not caught in Trixi.jl's downstream tests as we currently only run one Euler elixir.