### PR TITLE
more upstream tests

### DIFF
--- a/test/test_trixi_consistency.jl
+++ b/test/test_trixi_consistency.jl
@@ -16,12 +16,12 @@ isdir(outdir) && rm(outdir, recursive = true)
                             "elixir_euler_warm_bubble.jl")
 
     # Override fluxes, polydeg, cfl, maxiters
-    @test_trixi_include(trixi_elixir;
-                        volume_flux = Trixi.flux_chandrashekar,
-                        surface_flux = Trixi.FluxLMARS(360.0),
-                        polydeg = 4,
-                        stepsize_callback = Trixi.StepsizeCallback(cfl = 0.2),
-                        maxiters = maxiters)
+    trixi_include(trixi_elixir;
+                  volume_flux = Trixi.flux_chandrashekar,
+                  surface_flux = Trixi.FluxLMARS(360.0),
+                  polydeg = 4,
+                  stepsize_callback = Trixi.StepsizeCallback(cfl = 0.2),
+                  maxiters = maxiters)
 
     # Save errors
     errors_trixi = Main.analysis_callback(Main.sol)
@@ -44,10 +44,10 @@ isdir(outdir) && rm(outdir, recursive = true)
 
     # Override initial condition, maxiters,
     # gravitational acceleration constant to match Trixi's equations
-    @test_trixi_include(elixir_atmo;
-                        initial_condition = Main.warm_bubble_setup,
-                        gravity = 9.81,
-                        maxiters = maxiters)
+    trixi_include(elixir_atmo;
+                  initial_condition = Main.warm_bubble_setup,
+                  gravity = 9.81,
+                  maxiters = maxiters)
 
     # Save errors
     errors_atmo = Main.analysis_callback(Main.sol)


### PR DESCRIPTION
@JoshuaLampert noticed that the TrixiAtmo.jl upstream tests did not fail in https://github.com/trixi-framework/Trixi.jl/pull/2775#pullrequestreview-3749358500. The reason is that we did not check for warnings and ran only a few tests. Thus, I added additional checks for upstream CI runs.