### PR TITLE
Allow more allocations in threaded test

### DIFF
--- a/test/test_threaded.jl
+++ b/test/test_threaded.jl
@@ -29,7 +29,7 @@ include("test_trixiatmo.jl")
                         tspan=(0.0, 0.1))
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
-    @test_allocations(TrixiAtmo.Trixi.rhs!, semi, sol, 2000)
+    @test_allocations(TrixiAtmo.Trixi.rhs!, semi, sol, 2500)
 end
 end
 end # module


### PR DESCRIPTION
I just bisected this to updating Trixi.jl from v0.15.7 to v0.15.8. The explanation is that https://github.com/trixi-framework/Trixi.jl/pull/2831 introduced an additional threaded loop `prolong2interfaces!`. Since threaded code leads to some small amount of allocations, this explains the additional allocations.

With Trixi.jl v0.15.7:

```julia
julia> u_ode = copy(sol.u[end]); du_ode = similar(u_ode); @allocations Trixi.rhs!(du_ode, u_ode, semi, 0.0)
5

julia> u_ode = copy(sol.u[end]); du_ode = similar(u_ode); @allocated Trixi.rhs!(du_ode, u_ode, semi, 0.0)
1984
```

With Trixi.jl v0.15.8:

```julia
julia> u_ode = copy(sol.u[end]); du_ode = similar(u_ode); @allocations Trixi.rhs!(du_ode, u_ode, semi, 0.0)
6

julia> u_ode = copy(sol.u[end]); du_ode = similar(u_ode); @allocated Trixi.rhs!(du_ode, u_ode, semi, 0.0)
2352
```

We clearly see that there is one additional allocation caused by one additional threaded loop.

Closes #148 