### PR TITLE
Update affiliation for Tristan Montoya

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ TrixiAtmo.jl is maintained by the
 It was initiated by
 [Andrés Rueda-Ramírez](https://andres.rueda-ramirez.com)
 (Polytechnic University of Madrid (UPM), Spain),
-[Benedict Geihe](https://www.mi.uni-koeln.de/NumSim/), and
+[Benedict Geihe](https://www.mi.uni-koeln.de/NumSim/)
+(University of Cologne, Germany), and
 [Tristan Montoya](https://tjbmontoya.com/)
-(University of Cologne, Germany).
+(University of Saskatchewan, Canada).
 The full list of contributors can be found in [AUTHORS.md](AUTHORS.md).
 
 ## License and contributing


### PR DESCRIPTION
The readme has been updated to be consistent with the convention of listing current academic affiliation, which in my case is the University of Saskatchewan, Canada.