### PR TITLE
Add turbo baroclinic instability elixir

### DIFF
--- a/examples/euler/dry_air/global_circulation/elixir_potential_temperature_baroclinic_instability_turbo.jl
+++ b/examples/euler/dry_air/global_circulation/elixir_potential_temperature_baroclinic_instability_turbo.jl
@@ -1,0 +1,254 @@
+# An idealized baroclinic instability test case, using the specialization that combines
+# conservative and nonconservative fluxes in a single kernel, see
+# `Trixi.combine_conservative_and_nonconservative_fluxes`.
+# For optimal results consider increasing the resolution to 16x16x8 trees per cube face.
+#
+# This elixir takes about 8 hours, using 16 threads of an AMD Ryzen 7 7800X3D.
+#
+# References:
+# - Paul A. Ullrich, Thomas Melvin, Christiane Jablonowski, Andrew Staniforth (2013)
+#   A proposed baroclinic wave test case for deep- and shallow-atmosphere dynamical cores
+#   https://doi.org/10.1002/qj.2241
+
+using OrdinaryDiffEqSSPRK
+using Trixi, TrixiAtmo
+using LinearAlgebra: norm
+
+# Unperturbed balanced steady-state.
+# Returns primitive variables with only the velocity in longitudinal direction (rho, u, p).
+# The other velocity components are zero.
+function basic_state_baroclinic_instability_longitudinal_velocity(lon, lat, z)
+    # Parameters from Table 1 in the paper
+    # Corresponding names in the paper are commented
+    radius_earth = EARTH_RADIUS                                     # a
+    half_width_parameter = 2                                        # b
+    gravitational_acceleration = EARTH_GRAVITATIONAL_ACCELERATION   # g
+    k = 3                                                           # k
+    surface_pressure = 1.0f5                                        # p₀
+    gas_constant = 287                                              # R
+    surface_equatorial_temperature = 310                            # T₀ᴱ
+    surface_polar_temperature = 240                                 # T₀ᴾ
+    lapse_rate = 0.005                                              # Γ
+    angular_velocity = EARTH_ROTATION_RATE                          # Ω
+
+    # Distance to the center of the Earth
+    r = z + radius_earth
+
+    # In the paper: T₀
+    temperature0 = 0.5 * (surface_equatorial_temperature + surface_polar_temperature)
+    # In the paper: A, B, C, H
+    const_a = 1 / lapse_rate
+    const_b = (temperature0 - surface_polar_temperature) /
+              (temperature0 * surface_polar_temperature)
+    const_c = 0.5 * (k + 2) * (surface_equatorial_temperature - surface_polar_temperature) /
+              (surface_equatorial_temperature * surface_polar_temperature)
+    const_h = gas_constant * temperature0 / gravitational_acceleration
+
+    # In the paper: (r - a) / bH
+    scaled_z = z / (half_width_parameter * const_h)
+
+    # Temporary variables
+    temp1 = exp(lapse_rate / temperature0 * z)
+    temp2 = exp(-scaled_z^2)
+
+    # In the paper: ̃τ₁, ̃τ₂
+    tau1 = const_a * lapse_rate / temperature0 * temp1 +
+           const_b * (1 - 2 * scaled_z^2) * temp2
+    tau2 = const_c * (1 - 2 * scaled_z^2) * temp2
+
+    # In the paper: ∫τ₁(r') dr', ∫τ₂(r') dr'
+    inttau1 = const_a * (temp1 - 1) + const_b * z * temp2
+    inttau2 = const_c * z * temp2
+
+    # Temporary variables
+    temp3 = r / radius_earth * cos(lat)
+    temp4 = temp3^k - k / (k + 2) * temp3^(k + 2)
+
+    # In the paper: T
+    temperature = 1 / ((r / radius_earth)^2 * (tau1 - tau2 * temp4))
+
+    # In the paper: U, u (zonal wind, first component of spherical velocity)
+    big_u = gravitational_acceleration / radius_earth * k * temperature * inttau2 *
+            (temp3^(k - 1) - temp3^(k + 1))
+    temp5 = radius_earth * cos(lat)
+    u = -angular_velocity * temp5 + sqrt(angular_velocity^2 * temp5^2 + temp5 * big_u)
+
+    # Hydrostatic pressure
+    p = surface_pressure *
+        exp(-gravitational_acceleration / gas_constant * (inttau1 - inttau2 * temp4))
+
+    # Density (via ideal gas law)
+    rho = p / (gas_constant * temperature)
+
+    return rho, u, p
+end
+
+# Perturbation as in Equations 25 and 26 of the paper (analytical derivative)
+function perturbation_stream_function(lon, lat, z)
+    # Parameters from Table 1 in the paper
+    # Corresponding names in the paper are commented
+    perturbation_radius = 1 / 6      # d₀ / a
+    perturbed_wind_amplitude = 1      # Vₚ
+    perturbation_lon = pi / 9     # Longitude of perturbation location
+    perturbation_lat = 2 * pi / 9 # Latitude of perturbation location
+    pertz = 15000    # Perturbation height cap
+
+    # Great circle distance (d in the paper) divided by a (radius of the Earth)
+    # because we never actually need d without dividing by a
+    great_circle_distance_by_a = acos(sin(perturbation_lat) * sin(lat) +
+                                      cos(perturbation_lat) * cos(lat) *
+                                      cos(lon - perturbation_lon))
+
+    # In the first case, the vertical taper function is per definition zero.
+    # In the second case, the stream function is per definition zero.
+    if z > pertz || great_circle_distance_by_a > perturbation_radius
+        return 0, 0
+    end
+
+    # Vertical tapering of stream function
+    perttaper = 1 - 3 * z^2 / pertz^2 + 2 * z^3 / pertz^3
+
+    # sin/cos(pi * d / (2 * d_0)) in the paper
+    sin_, cos_ = sincos(0.5f0 * pi * great_circle_distance_by_a / perturbation_radius)
+
+    # Common factor for both u and v
+    factor = 16 / (3 * sqrt(3)) * perturbed_wind_amplitude * perttaper * cos_^3 * sin_
+
+    u_perturbation = -factor * (-sin(perturbation_lat) * cos(lat) +
+                      cos(perturbation_lat) * sin(lat) * cos(lon - perturbation_lon)) /
+                     sin(great_circle_distance_by_a)
+
+    v_perturbation = factor * cos(perturbation_lat) * sin(lon - perturbation_lon) /
+                     sin(great_circle_distance_by_a)
+
+    return u_perturbation, v_perturbation
+end
+
+function cartesian_to_sphere(x)
+    r = norm(x)
+    lambda = atan(x[2], x[1])
+    if lambda < 0
+        lambda += 2 * pi
+    end
+    phi = asin(x[3] / r)
+
+    return lambda, phi, r
+end
+
+# Initial condition for an idealized baroclinic instability test
+# https://doi.org/10.1002/qj.2241, Section 3.2 and Appendix A
+function initial_condition_baroclinic_instability(x, t,
+                                                  equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    lon, lat, r = cartesian_to_sphere(x)
+    radius_earth = EARTH_RADIUS
+    # Make sure that the r is not smaller than radius_earth
+    z = max(r - radius_earth, 0.0)
+
+    # Unperturbed basic state
+    rho, u, p = basic_state_baroclinic_instability_longitudinal_velocity(lon, lat, z)
+
+    # Stream function type perturbation
+    u_perturbation, v_perturbation = perturbation_stream_function(lon, lat, z)
+
+    u += u_perturbation
+    v = v_perturbation
+
+    # Convert spherical velocity to Cartesian
+    v1 = -sin(lon) * u - sin(lat) * cos(lon) * v
+    v2 = cos(lon) * u - sin(lat) * sin(lon) * v
+    v3 = cos(lat) * v
+    gravitational_acceleration = EARTH_GRAVITATIONAL_ACCELERATION  # g
+
+    r = norm(x)
+    # Make sure that r is not smaller than radius_earth
+    z = max(r - radius_earth, 0)
+    if z > 0
+        r = norm(x)
+    else
+        r = -(2 * radius_earth^3) / (x[1]^2 + x[2]^2 + x[3]^2)
+    end
+    r = -norm(x)
+    phi = radius_earth^2 * gravitational_acceleration / r
+
+    return prim2cons(SVector(rho, v1, v2, v3, p, phi), equations)
+end
+
+@inline function source_terms_baroclinic_instability(u, x, t,
+                                                     equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    radius_earth = EARTH_RADIUS  # a
+    angular_velocity = EARTH_ROTATION_RATE  # Ω
+
+    r = norm(x)
+    # Make sure that r is not smaller than radius_earth
+    z = max(r - radius_earth, 0)
+    r = z + radius_earth
+
+    du1 = zero(eltype(u))
+    du2 = zero(eltype(u))
+    du3 = zero(eltype(u))
+    du4 = zero(eltype(u))
+    du5 = zero(eltype(u))
+    # Coriolis term, -2Ω × ρv = -2 * angular_velocity * (0, 0, 1) × u[2:4]
+    du2 -= -2 * angular_velocity * u[3]
+    du3 -= 2 * angular_velocity * u[2]
+
+    return SVector(du1, du2, du3, du4, du5, zero(eltype(u)))
+end
+
+equations = CompressibleEulerPotentialTemperatureEquationsWithGravity3D(c_p = 1004,
+                                                                        c_v = 717,
+                                                                        gravity = EARTH_GRAVITATIONAL_ACCELERATION)
+
+initial_condition = initial_condition_baroclinic_instability
+
+boundary_conditions = (; inside = boundary_condition_slip_wall,
+                       outside = boundary_condition_slip_wall)
+
+polydeg = 5
+# The surface flux is equivalent to `(FluxLMARS(340), flux_zero)`, but returns both
+# contributions from a single kernel. The volume flux is equivalent to
+# `(flux_kennedy_gruber, flux_nonconservative_souza_etal)`, but `FluxTurbo` selects a
+# SIMD-vectorized implementation of the flux differencing volume integral.
+surface_flux = flux_lmars_combined
+volume_flux = FluxTurbo(flux_kennedy_gruber, flux_nonconservative_souza_etal)
+
+solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux,
+               volume_integral = VolumeIntegralFluxDifferencing(volume_flux))
+trees_per_cube_face = (8, 4)
+mesh = P4estMeshCubedSphereTopography(trees_per_cube_face..., EARTH_RADIUS, 30000,
+                                      polydeg = polydeg, initial_refinement_level = 0)
+
+semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                    source_terms = source_terms_baroclinic_instability,
+                                    boundary_conditions = boundary_conditions)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+T = 10 # 10 days
+tspan = (0.0, T * SECONDS_PER_DAY) # time in seconds for 10 days
+
+ode = semidiscretize(semi, tspan)
+
+summary_callback = SummaryCallback()
+
+analysis_interval = 1000
+analysis_callback = AnalysisCallback(semi, interval = analysis_interval)
+
+alive_callback = AliveCallback(analysis_interval = analysis_interval)
+
+save_solution = SaveSolutionCallback(dt = 100, save_initial_solution = true,
+                                     save_final_solution = true)
+
+callbacks = CallbackSet(summary_callback,
+                        analysis_callback,
+                        alive_callback,
+                        save_solution)
+
+###############################################################################
+# Use a Runge-Kutta method with automatic (error based) time step size control
+# Enable threading of the RK method for better performance on multiple threads
+tol = 1e-6
+sol = solve(ode,
+            SSPRK43(thread = Trixi.Threaded());
+            abstol = tol, reltol = tol, ode_default_options()...,
+            callback = callbacks)

--- a/examples/euler/dry_air/global_circulation/elixir_potential_temperature_baroclinic_instability_turbo.jl
+++ b/examples/euler/dry_air/global_circulation/elixir_potential_temperature_baroclinic_instability_turbo.jl
@@ -3,8 +3,6 @@
 # `Trixi.combine_conservative_and_nonconservative_fluxes`.
 # For optimal results consider increasing the resolution to 16x16x8 trees per cube face.
 #
-# This elixir takes about 8 hours, using 16 threads of an AMD Ryzen 7 7800X3D.
-#
 # References:
 # - Paul A. Ullrich, Thomas Melvin, Christiane Jablonowski, Andrew Staniforth (2013)
 #   A proposed baroclinic wave test case for deep- and shallow-atmosphere dynamical cores

--- a/src/TrixiAtmo.jl
+++ b/src/TrixiAtmo.jl
@@ -76,6 +76,8 @@ export flux_nonconservative_zeros, flux_nonconservative_ec,
        flux_ec_rain, flux_LMARS, flux_nonconservative_es, flux_conservative_es,
        flux_conservative_etec, flux_nonconservative_etec
 
+export flux_lmars_combined, flux_kennedy_gruber_souza_etal
+
 export source_terms_lagrange_multiplier, clean_solution_lagrange_multiplier!
 
 export cons2prim_and_vorticity, contravariant2global

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -1,5 +1,44 @@
 @muladd begin
 #! format: noindent
+
+@doc raw"""
+    CompressibleEulerPotentialTemperatureEquationsWithGravity3D(; c_p, c_v, gravity)
+
+The compressible Euler equations with gravity in potential temperature formulation
+```math
+\frac{\partial}{\partial t}
+\begin{pmatrix}
+\rho \\ \rho v_1 \\ \rho v_2 \\ \rho v_3 \\ \rho \theta
+\end{pmatrix}
++
+\frac{\partial}{\partial x}
+\begin{pmatrix}
+\rho v_1 \\ \rho v_1^2 + p \\ \rho v_1 v_2 \\ \rho v_1 v_3 \\ \rho \theta v_1
+\end{pmatrix}
++
+\frac{\partial}{\partial y}
+\begin{pmatrix}
+\rho v_2 \\ \rho v_1 v_2 \\ \rho v_2^2 + p \\ \rho v_2 v_3 \\ \rho \theta v_2
+\end{pmatrix}
++
+\frac{\partial}{\partial z}
+\begin{pmatrix}
+\rho v_3 \\ \rho v_1 v_3 \\ \rho v_2 v_3 \\ \rho v_3^2 + p \\ \rho \theta v_3
+\end{pmatrix}
+=
+\begin{pmatrix}
+0 \\ -\rho \frac{\partial}{\partial x} \phi \\ -\rho \frac{\partial}{\partial y} \phi \\ -\rho \frac{\partial}{\partial z} \phi \\ 0
+\end{pmatrix}
+```
+for an ideal gas with ratio of specific heats ``\gamma = c_p / c_v`` in three space dimensions.
+Here, ``\rho`` is the density, ``v_1, v_2, v_3`` are the velocities, ``\theta`` is the
+potential temperature, ``\phi`` is the gravitational potential, and
+```math
+p = p_0 \left( \frac{R \rho \theta}{p_0} \right)^\gamma
+```
+the pressure, where ``p_0 = 10^5\,\mathrm{Pa}`` is the reference pressure and
+``R = c_p - c_v`` the gas constant.
+"""
 struct CompressibleEulerPotentialTemperatureEquationsWithGravity3D{RealT <: Real} <:
        AbstractCompressibleEulerEquations{3, 6}
     p_0::RealT # reference pressure in Pa

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -27,6 +27,19 @@ struct CompressibleEulerPotentialTemperatureEquationsWithGravity3D{RealT <: Real
     end
 end
 
+# Together with the specialization of `Adapt.adapt_structure` in Trixi.jl, this allows to
+# move semidiscretizations and their components including the equations to GPUs and to adapt
+# the floating point type, e.g., to `Float32` to improve performance on GPUs.
+function Base.similar(equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D,
+                      ::Type{NewRealT}) where {NewRealT}
+    return CompressibleEulerPotentialTemperatureEquationsWithGravity3D(c_p = convert(NewRealT,
+                                                                                     equations.c_p),
+                                                                       c_v = convert(NewRealT,
+                                                                                     equations.c_v),
+                                                                       gravity = convert(NewRealT,
+                                                                                         equations.g))
+end
+
 function varnames(::typeof(cons2cons),
                   ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
     ("rho", "rho_v1", "rho_v2", "rho_v3", "rho_theta", "phi")
@@ -202,6 +215,179 @@ end
                    f4 + p_interface * normal_direction[3],
                    f5, zero(eltype(u_ll)))
 end
+
+"""
+    flux_lmars_combined(u_ll, u_rr, normal_direction,
+                        equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+
+Version of the low Mach number approximate Riemann solver `FluxLMARS(340)` that returns the
+conservative and the nonconservative contribution of the surface flux as a tuple, see
+[`Trixi.combine_conservative_and_nonconservative_fluxes`](@ref). It is therefore used as a
+single `surface_flux` instead of the tuple `(FluxLMARS(340), flux_zero)`.
+
+The geopotential is continuous across interfaces, so the nonconservative gravity term, which
+is proportional to the jump of the geopotential, vanishes on the surface. Hence both
+contributions are given by the plain LMARS flux and no gravity term is computed here.
+"""
+@inline function flux_lmars_combined(u_ll, u_rr,
+                                     normal_direction::AbstractVector,
+                                     equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    # constants
+    a = 340
+
+    # Unpack left and right state
+    rho_ll, v1_ll, v2_ll, v3_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, v3_rr, p_rr = cons2prim(u_rr, equations)
+
+    v_ll = v1_ll * normal_direction[1] + v2_ll * normal_direction[2] +
+           v3_ll * normal_direction[3]
+    v_rr = v1_rr * normal_direction[1] + v2_rr * normal_direction[2] +
+           v3_rr * normal_direction[3]
+
+    norm_ = norm(normal_direction)
+
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+
+    p_interface = 0.5f0 * (p_ll + p_rr) - 0.5f0 * a * rho_avg * (v_rr - v_ll) / norm_
+    v_interface = 0.5f0 * (v_ll + v_rr) - 1 / (2 * a * rho_avg) * (p_rr - p_ll) * norm_
+
+    if (v_interface > 0)
+        f1, f2, f3, f4, f5 = u_ll * v_interface
+    else
+        f1, f2, f3, f4, f5 = u_rr * v_interface
+    end
+
+    flux = SVector(f1,
+                   f2 + p_interface * normal_direction[1],
+                   f3 + p_interface * normal_direction[2],
+                   f4 + p_interface * normal_direction[3],
+                   f5, zero(eltype(u_ll)))
+
+    return flux, flux
+end
+
+@inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_lmars_combined), ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D) = Trixi.True()
+
+# The boundary condition must also be specialized for a combined surface flux such that it
+# returns only the first contribution of the surface flux.
+@inline function boundary_condition_slip_wall(u_inner,
+                                              normal_direction::AbstractVector,
+                                              x, t,
+                                              surface_flux_function::typeof(flux_lmars_combined),
+                                              equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    # normalize the outward pointing direction
+    normal = normal_direction / norm(normal_direction)
+    # compute the normal velocity
+    u_normal = normal[1] * u_inner[2] + normal[2] * u_inner[3] + normal[3] * u_inner[4]
+
+    # create the "external" boundary solution state
+    u_boundary = SVector(u_inner[1],
+                         u_inner[2] - 2 * u_normal * normal[1],
+                         u_inner[3] - 2 * u_normal * normal[2],
+                         u_inner[4] - 2 * u_normal * normal[3],
+                         u_inner[5], u_inner[6])
+
+    # calculate the boundary flux
+    flux, _ = surface_flux_function(u_inner, u_boundary, normal_direction, equations)
+
+    return flux
+end
+
+"""
+    flux_kennedy_gruber(u_ll, u_rr, normal_direction,
+                        equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+
+Kinetic energy preserving two-point flux by
+- Kennedy and Gruber (2008)
+  Reduced aliasing formulations of the convective terms within the
+  Navier-Stokes equations for a compressible fluid
+  [DOI: 10.1016/j.jcp.2007.09.020](https://doi.org/10.1016/j.jcp.2007.09.020)
+"""
+@inline function flux_kennedy_gruber(u_ll, u_rr, normal_direction::AbstractVector,
+                                     equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    # Unpack left and right state
+    rho_theta_ll = u_ll[5]
+    rho_theta_rr = u_rr[5]
+    rho_ll, v1_ll, v2_ll, v3_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, v3_rr, p_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v3_avg = 0.5f0 * (v3_ll + v3_rr)
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    theta_avg = 0.5f0 * (rho_theta_ll / rho_ll + rho_theta_rr / rho_rr)
+
+    v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2] +
+                  v3_avg * normal_direction[3]
+
+    # Calculate fluxes depending on normal_direction
+    f1 = rho_avg * v_dot_n_avg
+    f2 = f1 * v1_avg + p_avg * normal_direction[1]
+    f3 = f1 * v2_avg + p_avg * normal_direction[2]
+    f4 = f1 * v3_avg + p_avg * normal_direction[3]
+    f5 = f1 * theta_avg
+
+    return SVector(f1, f2, f3, f4, f5, zero(eltype(u_ll)))
+end
+
+"""
+    flux_kennedy_gruber_souza_etal(u_ll, u_rr, normal_direction,
+                                   equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+
+Fused version of [`flux_kennedy_gruber`](@ref) and [`flux_nonconservative_souza_etal`](@ref)
+that computes the conservative and the nonconservative contributions in a single kernel,
+returning the tuple
+
+    flux_kennedy_gruber(u_ll, u_rr, n, equations)
+        ± 0.5f0 * flux_nonconservative_souza_etal(u_ll, u_rr, n, equations)
+
+see [`Trixi.combine_conservative_and_nonconservative_fluxes`](@ref). It is therefore used as
+a single `volume_flux` instead of the tuple
+`(flux_kennedy_gruber, flux_nonconservative_souza_etal)`.
+"""
+@inline function flux_kennedy_gruber_souza_etal(u_ll, u_rr,
+                                                normal_direction::AbstractVector,
+                                                equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    # Unpack left and right state
+    rho_theta_ll = u_ll[5]
+    rho_theta_rr = u_rr[5]
+    phi_ll = u_ll[6]
+    phi_rr = u_rr[6]
+    rho_ll, v1_ll, v2_ll, v3_ll, p_ll = cons2prim(u_ll, equations)
+    rho_rr, v1_rr, v2_rr, v3_rr, p_rr = cons2prim(u_rr, equations)
+
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v3_avg = 0.5f0 * (v3_ll + v3_rr)
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    theta_avg = 0.5f0 * (rho_theta_ll / rho_ll + rho_theta_rr / rho_rr)
+
+    v_dot_n_avg = v1_avg * normal_direction[1] + v2_avg * normal_direction[2] +
+                  v3_avg * normal_direction[3]
+
+    # Conservative part, cf. `flux_kennedy_gruber`
+    f1 = rho_avg * v_dot_n_avg
+    f2 = f1 * v1_avg + p_avg * normal_direction[1]
+    f3 = f1 * v2_avg + p_avg * normal_direction[2]
+    f4 = f1 * v3_avg + p_avg * normal_direction[3]
+    f5 = f1 * theta_avg
+
+    # Nonconservative part, cf. `flux_nonconservative_souza_etal`, scaled by 0.5
+    gravity = 0.5f0 * rho_avg * (phi_rr - phi_ll)
+    g2 = normal_direction[1] * gravity
+    g3 = normal_direction[2] * gravity
+    g4 = normal_direction[3] * gravity
+
+    zero_ = zero(eltype(u_ll))
+    return SVector(f1, f2 + g2, f3 + g3, f4 + g4, f5, zero_),
+           SVector(f1, f2 - g2, f3 - g3, f4 - g4, f5, zero_)
+end
+
+@inline Trixi.combine_conservative_and_nonconservative_fluxes(::typeof(flux_kennedy_gruber_souza_etal), ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D) = Trixi.True()
 
 """
 	flux_tec(u_ll, u_rr, orientation_or_normal_direction, equations::CompressibleEulerEquationsPotentialTemperatureWithGravity3D)
@@ -487,3 +673,64 @@ end
     return abs(v1) + c, abs(v2) + c, abs(v3) + c
 end
 end # @muladd
+
+# Specializations of the `FluxTurbo` interface of Trixi.jl.
+const FluxKennedyGruberSouzaEtal = Tuple{typeof(flux_kennedy_gruber),
+                                         typeof(flux_nonconservative_souza_etal)}
+
+# We precompute `rho, v1, v2, v3, theta, p, phi`, i.e., one quantity more than the number
+# of variables.
+@inline function Trixi.nturbovars(::FluxKennedyGruberSouzaEtal,
+                                  ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    return Val(7)
+end
+
+@inline function Trixi.cons2turbo(::FluxKennedyGruberSouzaEtal,
+                                  rho, rho_v1, rho_v2, rho_v3, rho_theta, phi,
+                                  equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    v1 = rho_v1 / rho
+    v2 = rho_v2 / rho
+    v3 = rho_v3 / rho
+    theta = rho_theta / rho
+    p = equations.K * exp(equations.gamma * log(rho_theta))
+
+    return rho, v1, v2, v3, theta, p, phi
+end
+
+@inline function Trixi.flux_turbo(::FluxKennedyGruberSouzaEtal,
+                                  rho_ll, v1_ll, v2_ll, v3_ll, theta_ll, p_ll, phi_ll,
+                                  rho_rr, v1_rr, v2_rr, v3_rr, theta_rr, p_rr, phi_rr,
+                                  normal_direction_1, normal_direction_2,
+                                  normal_direction_3,
+                                  equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
+    # Average each factor of products in flux
+    rho_avg = 0.5f0 * (rho_ll + rho_rr)
+    v1_avg = 0.5f0 * (v1_ll + v1_rr)
+    v2_avg = 0.5f0 * (v2_ll + v2_rr)
+    v3_avg = 0.5f0 * (v3_ll + v3_rr)
+    p_avg = 0.5f0 * (p_ll + p_rr)
+    theta_avg = 0.5f0 * (theta_ll + theta_rr)
+
+    v_dot_n_avg = v1_avg * normal_direction_1 + v2_avg * normal_direction_2 +
+                  v3_avg * normal_direction_3
+
+    # Conservative part, i.e. 'flux_kennedy_gruber'
+    f1 = rho_avg * v_dot_n_avg
+    f2 = f1 * v1_avg + p_avg * normal_direction_1
+    f3 = f1 * v2_avg + p_avg * normal_direction_2
+    f4 = f1 * v3_avg + p_avg * normal_direction_3
+    f5 = f1 * theta_avg
+
+    # Nonconservative part, i.e., `flux_nonconservative_souza_etal`, scaled by 0.5. Since this
+    # flux is antisymmetric, the right contribution is obtained by flipping the sign.
+    gravity = 0.5f0 * rho_avg * (phi_rr - phi_ll)
+    g2 = normal_direction_1 * gravity
+    g3 = normal_direction_2 * gravity
+    g4 = normal_direction_3 * gravity
+
+    zero_ = zero(eltype(rho_ll))
+    flux_left = (f1, f2 + g2, f3 + g3, f4 + g4, f5, zero_)
+    flux_right = (f1, f2 - g2, f3 - g3, f4 - g4, f5, zero_)
+
+    return flux_left, flux_right
+end

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -27,7 +27,6 @@ struct CompressibleEulerPotentialTemperatureEquationsWithGravity3D{RealT <: Real
     end
 end
 
-
 function varnames(::typeof(cons2cons),
                   ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
     ("rho", "rho_v1", "rho_v2", "rho_v3", "rho_theta", "phi")

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -285,7 +285,7 @@ end
                         equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
 
 Modification of the kinetic-energy-preserving two-point flux by Kennedy and Gruber
-that is consistent with ['CompressibleEulerPotentialTemperatureEquationsWithGravity3D'](@ref). See:
+that is consistent with [`CompressibleEulerPotentialTemperatureEquationsWithGravity3D`](@ref). See:
 - Kennedy and Gruber (2008)
   Reduced aliasing formulations of the convective terms within the
   Navier-Stokes equations for a compressible fluid

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -284,7 +284,8 @@ end
     flux_kennedy_gruber(u_ll, u_rr, normal_direction,
                         equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)
 
-Kinetic energy preserving two-point flux by
+Modification of the kinetic-energy-preserving two-point flux by Kennedy and Gruber
+that is consistent with ['CompressibleEulerPotentialTemperatureEquationsWithGravity3D'](@ref). See:
 - Kennedy and Gruber (2008)
   Reduced aliasing formulations of the convective terms within the
   Navier-Stokes equations for a compressible fluid

--- a/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
+++ b/src/equations/compressible_euler_potential_temperature_gravity_3d.jl
@@ -27,18 +27,6 @@ struct CompressibleEulerPotentialTemperatureEquationsWithGravity3D{RealT <: Real
     end
 end
 
-# Together with the specialization of `Adapt.adapt_structure` in Trixi.jl, this allows to
-# move semidiscretizations and their components including the equations to GPUs and to adapt
-# the floating point type, e.g., to `Float32` to improve performance on GPUs.
-function Base.similar(equations::CompressibleEulerPotentialTemperatureEquationsWithGravity3D,
-                      ::Type{NewRealT}) where {NewRealT}
-    return CompressibleEulerPotentialTemperatureEquationsWithGravity3D(c_p = convert(NewRealT,
-                                                                                     equations.c_p),
-                                                                       c_v = convert(NewRealT,
-                                                                                     equations.c_v),
-                                                                       gravity = convert(NewRealT,
-                                                                                         equations.g))
-end
 
 function varnames(::typeof(cons2cons),
                   ::CompressibleEulerPotentialTemperatureEquationsWithGravity3D)

--- a/test/test_3d_potential_temperature.jl
+++ b/test/test_3d_potential_temperature.jl
@@ -176,6 +176,27 @@ end
     @test_allocations(TrixiAtmo.Trixi.rhs_hyperbolic!, semi, sol, 100)
 end
 
+@trixi_testset "elixir_potential_temperature_baroclinic_instability with combined fluxes" begin
+    trixi_include(@__MODULE__,
+                  joinpath(EXAMPLES_DIR, "global_circulation",
+                           "elixir_potential_temperature_baroclinic_instability_turbo.jl"),
+                  tspan = (0.0, 100.0), trees_per_cube_face = (2, 2))
+    u_ode_specialized = copy(sol.u[end])
+
+    trixi_include(@__MODULE__,
+                  joinpath(EXAMPLES_DIR, "global_circulation",
+                           "elixir_potential_temperature_baroclinic_instability.jl"),
+                  surface_flux = (FluxLMARS(340), flux_zero),
+                  volume_flux = (flux_kennedy_gruber, flux_nonconservative_souza_etal),
+                  tspan = (0.0, 100.0), trees_per_cube_face = (2, 2))
+    u_ode = copy(sol.u[end])
+
+    @test u_ode_specialized ≈ u_ode
+    # Ensure that we do not have excessive memory allocations
+    # (e.g., from type instabilities)
+    @test_allocations(TrixiAtmo.Trixi.rhs_hyperbolic!, semi, sol, 100)
+end
+
 @trixi_testset "elixir_potential_temperature_held_suarez" begin
     import ..CI_ON_MACOS
     if CI_ON_MACOS

--- a/test/test_3d_potential_temperature.jl
+++ b/test/test_3d_potential_temperature.jl
@@ -183,6 +183,15 @@ end
                   tspan = (0.0, 100.0), trees_per_cube_face = (2, 2))
     u_ode_specialized = copy(sol.u[end])
 
+    # Same combined surface flux, but with the fused combined volume flux instead of the
+    # SIMD-vectorized flux differencing volume integral selected by `FluxTurbo`.
+    trixi_include(@__MODULE__,
+                  joinpath(EXAMPLES_DIR, "global_circulation",
+                           "elixir_potential_temperature_baroclinic_instability_turbo.jl"),
+                  volume_flux = flux_kennedy_gruber_souza_etal,
+                  tspan = (0.0, 100.0), trees_per_cube_face = (2, 2))
+    u_ode_combined = copy(sol.u[end])
+
     trixi_include(@__MODULE__,
                   joinpath(EXAMPLES_DIR, "global_circulation",
                            "elixir_potential_temperature_baroclinic_instability.jl"),
@@ -192,6 +201,7 @@ end
     u_ode = copy(sol.u[end])
 
     @test u_ode_specialized ≈ u_ode
+    @test u_ode_combined ≈ u_ode
     # Ensure that we do not have excessive memory allocations
     # (e.g., from type instabilities)
     @test_allocations(TrixiAtmo.Trixi.rhs_hyperbolic!, semi, sol, 100)

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -268,13 +268,15 @@ end
               RealT
         @test eltype(@inferred flux_etec(u_ll, u_rr, normal_direction, equations)) ==
               RealT
-        @test eltype(@inferred flux_kennedy_gruber(u_ll, u_rr, normal_direction, equations)) ==
-              RealT
-        @test eltype(@inferred flux_lmars_combined(u_ll, u_rr, normal_direction, equations)) ==
-              RealT
-        @test eltype(@inferred flux_kennedy_gruber_souza_etal(u_ll, u_rr, normal_direction,
-                                                              equations)) ==
-              RealT
+        for i in 1:2
+            @test eltype(@inferred flux_kennedy_gruber(u_ll, u_rr, normal_direction, equations)[i]) ==
+                  RealT
+            @test eltype(@inferred flux_lmars_combined(u_ll, u_rr, normal_direction, equations)[i]) ==
+                  RealT
+            @test eltype(@inferred flux_kennedy_gruber_souza_etal(u_ll, u_rr, normal_direction,
+                                                                  equations)[i]) ==
+                  RealT
+        end
         @test eltype(@inferred cons2prim(u, equations)) == RealT
         @test eltype(@inferred prim2cons(u, equations)) == RealT
         @test eltype(@inferred cons2entropy(u, equations)) == RealT

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -269,11 +269,14 @@ end
         @test eltype(@inferred flux_etec(u_ll, u_rr, normal_direction, equations)) ==
               RealT
         for i in 1:2
-            @test eltype(@inferred flux_kennedy_gruber(u_ll, u_rr, normal_direction, equations)[i]) ==
+            @test eltype(@inferred flux_kennedy_gruber(u_ll, u_rr, normal_direction,
+                                                       equations)[i]) ==
                   RealT
-            @test eltype(@inferred flux_lmars_combined(u_ll, u_rr, normal_direction, equations)[i]) ==
+            @test eltype(@inferred flux_lmars_combined(u_ll, u_rr, normal_direction,
+                                                       equations)[i]) ==
                   RealT
-            @test eltype(@inferred flux_kennedy_gruber_souza_etal(u_ll, u_rr, normal_direction,
+            @test eltype(@inferred flux_kennedy_gruber_souza_etal(u_ll, u_rr,
+                                                                  normal_direction,
                                                                   equations)[i]) ==
                   RealT
         end

--- a/test/test_type.jl
+++ b/test/test_type.jl
@@ -268,6 +268,13 @@ end
               RealT
         @test eltype(@inferred flux_etec(u_ll, u_rr, normal_direction, equations)) ==
               RealT
+        @test eltype(@inferred flux_kennedy_gruber(u_ll, u_rr, normal_direction, equations)) ==
+              RealT
+        @test eltype(@inferred flux_lmars_combined(u_ll, u_rr, normal_direction, equations)) ==
+              RealT
+        @test eltype(@inferred flux_kennedy_gruber_souza_etal(u_ll, u_rr, normal_direction,
+                                                              equations)) ==
+              RealT
         @test eltype(@inferred cons2prim(u, equations)) == RealT
         @test eltype(@inferred prim2cons(u, equations)) == RealT
         @test eltype(@inferred cons2entropy(u, equations)) == RealT


### PR DESCRIPTION
Adding the `FluxTurbo` support for `flux_kennedy_gruber` (the name is a bit ambiguous as flux_kennedy gruber is for the formulation with the total energy and there's no such equivalent for the potential temperature; it can be changed with `flux_avg` `flux_central_avg` `flux_central_mean`...) and the combined flux for `FluxLMARS`.